### PR TITLE
To-one, optional relationships

### DIFF
--- a/Sources/Property.swift
+++ b/Sources/Property.swift
@@ -3,14 +3,14 @@ import Result
 
 public enum PropertyType {
     case toMany(AnyModel.Type)
-    case toOne(AnyModel.Type)
+    case toOne(AnyModel.Type, nullable: Bool)
     case value(AnyModelValue.Type, nullable: Bool)
 }
 
 extension PropertyType: Hashable {
     public var hashValue: Int {
         switch self {
-        case let .toMany(anyModel), let .toOne(anyModel):
+        case let .toMany(anyModel), let .toOne(anyModel, _):
             return ObjectIdentifier(anyModel).hashValue
         case let .value(anyModelValue, _):
             return ObjectIdentifier(anyModelValue).hashValue
@@ -19,9 +19,10 @@ extension PropertyType: Hashable {
     
     public static func ==(lhs: PropertyType, rhs: PropertyType) -> Bool {
         switch (lhs, rhs) {
-        case let (.toMany(lhs), .toMany(rhs)),
-             let (.toOne(lhs), .toOne(rhs)):
+        case let (.toMany(lhs), .toMany(rhs)):
             return lhs == rhs
+        case let (.toOne(lhs, lhsNullable), .toOne(rhs, rhsNullable)):
+            return lhs == rhs && lhsNullable == rhsNullable
         case let (.value(lhs, lhsNullable), .value(rhs, rhsNullable)):
             return lhs == rhs && lhsNullable == rhsNullable
         default:

--- a/Sources/PropertyCreation.swift
+++ b/Sources/PropertyCreation.swift
@@ -19,6 +19,17 @@ public func ~ <Model, Child: Schemata.Model>(
     )
 }
 
+public func ~ <Model, Child: Schemata.Model>(
+    lhs: KeyPath<Model, Set<Child>>,
+    rhs: KeyPath<Child, Model?>
+) -> Property<Model, Set<Child>> {
+    return Property<Model, Set<Child>>(
+        keyPath: lhs,
+        path: "(\(Child.self))",
+        type: .toMany(Child.self)
+    )
+}
+
 public func ~ <Model, Value: Schemata.Model>(
     lhs: KeyPath<Model, Value>,
     rhs: String
@@ -26,7 +37,18 @@ public func ~ <Model, Value: Schemata.Model>(
     return Property<Model, Value>(
         keyPath: lhs,
         path: rhs,
-        type: .toOne(Value.self)
+        type: .toOne(Value.self, nullable: false)
+    )
+}
+
+public func ~ <Model, Value: Schemata.Model>(
+    lhs: KeyPath<Model, Value?>,
+    rhs: String
+    ) -> Property<Model, Value?> {
+    return Property<Model, Value?>(
+        keyPath: lhs,
+        path: rhs,
+        type: .toOne(Value.self, nullable: true)
     )
 }
 

--- a/Sources/Schema.swift
+++ b/Sources/Schema.swift
@@ -27,7 +27,7 @@ public struct Schema<Model: Schemata.Model> {
                 return next.properties
             }
             
-            if case let .toOne(type)? = next.properties.last?.type {
+            if case let .toOne(type, _)? = next.properties.last?.type {
                 for property in type.anySchema.properties.values {
                     queue.append((
                         keyPath: next.keyPath.appending(path: property.keyPath)!,


### PR DESCRIPTION
Swift's KeyPaths lack the ability to do this. So this is blocked for now.

https://bugs.swift.org/browse/SR-5689